### PR TITLE
Add 'eb init' step to deploy docs

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -12,6 +12,16 @@ In order to deploy or configure the development environment, you must have [inst
 The `master` branch is deployed to an application called `universal-search-recommendation-dev`, in an environment called `us-recommendation-dev`. To configure your clone to deploy, ensure that the master branch is checked out and run:
 
 ```sh
+eb init
+```
+
+At the first prompt, choose **us-west-2** as the default region.
+
+At the second prompt, choose **universal-search-recommendation-dev** as the application to use.
+
+Next, run:
+
+```sh
 eb use us-recommendation-dev
 ```
 


### PR DESCRIPTION
@chuckharmston r?

Looks like we can't skip the `eb init` step, so I've added it to the docs.

<img width="438" alt="screenshot 2016-01-14 12 22 07" src="https://cloud.githubusercontent.com/assets/96396/12336433/7ad68b4a-bab9-11e5-8941-15d6645233b8.png">
