### PR TITLE
Calculates recommendation in a worker (closes #11):

### DIFF
--- a/app/conf.py
+++ b/app/conf.py
@@ -1,11 +1,15 @@
 from os import environ as env
 
 
+KEY_PREFIX = env.get('RECOMMENDATION_KEY_PREFIX', 'query_')
+
 DEBUG = env.get('RECOMMENDATION_ENV', 'development') == 'development'
 HOST = env.get('RECOMMENDATION_HOST', '0.0.0.0')
 PORT = env.get('RECOMMENDATION_PORT', 5000)
 
-MEMCACHED_HOST = env.get('MEMCACHED_HOST', '127.0.0.1')
+CELERY_BROKER_URL = env.get('CELERY_BROKER_URL', 'redis://redis:6379/0')
+
+MEMCACHED_HOST = env.get('MEMCACHED_HOST', 'memcached:11211')
 
 EMBEDLY_API_KEY = env.get('EMBEDLY_API_KEY', '')
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,12 +1,26 @@
+import hashlib
+
 from flask import abort, Flask, jsonify, request
 
-from app.conf import DEBUG
-from app.memorize import CacheMissError
+from app import conf
+from app.util import make_queue
+from app.memcached import memcached
 from app.search.recommendation import SearchRecommendation
 
 
 application = Flask(__name__)
-application.config['DEBUG'] = DEBUG
+application.config.update(
+    CELERY_BROKER_URL=conf.CELERY_BROKER_URL,
+    DEBUG=conf.DEBUG
+)
+queue = make_queue(application)
+
+
+@queue.task(name='main.recommend')
+def recommend(q, key):
+    recommendation = SearchRecommendation(q).do_search(q)
+    memcached.set(key, recommendation)
+    return recommendation
 
 
 @application.route('/')
@@ -14,14 +28,18 @@ def main():
     q = request.args.get('q')
     if not q:
         abort(400)
+    key = '_'.join([
+        conf.KEY_PREFIX,
+        hashlib.md5(str(q).encode('utf-8')).hexdigest()
+    ])
     try:
-        recommendation = SearchRecommendation(q, request)
-        response = recommendation.do_search(q)
-    except CacheMissError:
-        return jsonify({}), 202
+        response = memcached.get(key)
     except Exception as e:
         if application.config['DEBUG']:
             return jsonify({e.__class__.__name__: e.args}), 500
         return jsonify({}), 500
+    if not response:
+        recommend.delay(q, key)
+        return jsonify({}), 202
     else:
         return jsonify(response), 200

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,6 +1,7 @@
 -e git+https://github.com/linsomniac/python-memcached.git@37f55ca4ad94ca4ade30d6be28e1facb79ac3182#egg=python-memcached
 
 bleach==1.4.2
+celery==3.1.20
 coverage==4.0.3
 coveralls==1.1
 flake8==2.5.1
@@ -11,6 +12,7 @@ Jinja2==2.8
 MarkupSafe==0.23
 nose==1.3.7
 oauth2==1.9.0.post1
+redis==2.10.5
 requests==2.9.1
 responses==0.5.1
 uwsgi==2.0.12

--- a/app/search/recommendation.py
+++ b/app/search/recommendation.py
@@ -1,4 +1,3 @@
-from app.memorize import memorize
 from app.search.classification import CLASSIFIERS
 from app.search.query.yahoo import YahooQueryEngine
 from app.search.suggest.bing import BingSuggestionEngine
@@ -17,8 +16,8 @@ class SearchRecommendation(object):
       sequentially determine if they match the result, then enhance the result
       if so.
     """
-    def __init__(self, query, request):
-        self.request = request
+    def __init__(self, query):
+        self.query = query
 
     def get_suggestion_engine(self):
         """
@@ -75,7 +74,6 @@ class SearchRecommendation(object):
             'enhancements': {c.type: c.enhance() for c in classifiers}
         }
 
-    @memorize(prefix='search', error_on_miss=True)
     def do_search(self, query):
         """
         The full search lifecycle, encapsulated in a method for easy

--- a/app/search/tests/test_recommendation.py
+++ b/app/search/tests/test_recommendation.py
@@ -3,7 +3,6 @@ from unittest import TestCase
 from mock import patch
 from nose.tools import eq_, ok_
 
-from app.memorize import CacheMissError
 from app.search.classification.domain import DomainClassifier
 from app.search.classification.tests.test_domain import DOMAIN
 from app.search.recommendation import SearchRecommendation
@@ -23,7 +22,7 @@ QUERY = 'Cubs'
 
 class TestSearchRecommendation(TestCase):
     def setUp(self):
-        self.instance = SearchRecommendation('', None)
+        self.instance = SearchRecommendation('')
 
     def tearDown(self):
         mock_memcached.flush_all()
@@ -85,11 +84,8 @@ class TestSearchRecommendation(TestCase):
         mock_result.return_value = result
         mock_classifiers.return_value = classifiers
 
-        with self.assertRaises(CacheMissError):
-            self.instance.do_search(QUERY)
         search = self.instance.do_search(QUERY)
 
-        ok_(search.from_cache)
         ok_(all([k in search for k in ['enhancements', 'query', 'result']]))
         eq_(list(search['enhancements'].keys()), [c.type for c in classifiers])
         eq_(search['enhancements']['domain'], classifiers[0].enhance())

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -1,13 +1,15 @@
 from urllib.parse import urlencode
+from unittest import TestCase
 
-from flask.ext.testing import TestCase
+from flask.ext.testing import TestCase as FlaskTestCase
 from mock import patch
 from nose.tools import eq_
 
-from app.main import application
-from app.memorize import CacheMissError
+from app.main import application, recommend
+from app.tests.memcached import mock_memcached
 
 
+KEY = 'query_key'
 QUERY = 'frend'
 RESULTS = {
     'hello': 'frend'
@@ -16,12 +18,17 @@ EXCEPTION_ARGS = ['args']
 EXCEPTION = RuntimeError(*EXCEPTION_ARGS)
 
 
-class TestApp(TestCase):
+@patch('app.main.memcached', mock_memcached)
+class TestApp(FlaskTestCase):
     debug = False
+
+    def tearDown(self):
+        mock_memcached.flush_all()
 
     def create_app(self):
         app = application
         app.config['DEBUG'] = self.debug
+        app.config['PRESERVE_CONTEXT_ON_EXCEPTION'] = False
         return app
 
     def _get(self, path):
@@ -36,35 +43,49 @@ class TestApp(TestCase):
     def test_no_query(self):
         eq_(self._get('/').status_code, 400)
 
-    @patch('app.search.recommendation.SearchRecommendation.__init__')
-    def test_cache_miss(self, mock_recommendation):
-        mock_recommendation.side_effect = CacheMissError
-        response = self._query(QUERY)
-        eq_(response.status_code, 202)
-        eq_(response.json, {})
-
-    @patch('app.search.recommendation.SearchRecommendation.do_search')
-    def test_exception(self, mock_do_search):
-        mock_do_search.side_effect = EXCEPTION
+    @patch('app.tests.memcached.mock_memcached.get')
+    def test_exception(self, mock_get):
+        mock_get.side_effect = EXCEPTION
         response = self._query(QUERY)
         eq_(response.status_code, 500)
         eq_(response.json, {})
 
-    @patch('app.search.recommendation.SearchRecommendation.do_search')
-    def test_cache_hit(self, mock_do_search):
-        mock_do_search.return_value = RESULTS
+    @patch('app.tests.memcached.mock_memcached.get')
+    @patch('app.main.recommend.delay')
+    def test_cache_hit(self, mock_delay, mock_get):
+        mock_get.return_value = RESULTS
         eq_(self._query(QUERY).status_code, 200)
         eq_(self._query(QUERY).json, RESULTS)
+
+    @patch('app.tests.memcached.mock_memcached.get')
+    @patch('app.main.recommend.delay')
+    def test_cache_miss(self, mock_delay, mock_get):
+        mock_get.return_value = None
+        eq_(self._query(QUERY).status_code, 202)
+        eq_(mock_delay.call_count, 1)
 
 
 class TestAppDebug(TestApp):
     debug = True
 
-    @patch('app.search.recommendation.SearchRecommendation.do_search')
-    def test_exception(self, mock_do_search):
-        mock_do_search.side_effect = EXCEPTION
+    @patch('app.main.memcached.get')
+    @patch('app.main.recommend.delay')
+    def test_exception(self, mock_delay, mock_get):
+        mock_get.side_effect = EXCEPTION
         response = self._query(QUERY)
         exception_name = list(response.json.keys())[0]
         eq_(response.status_code, 500)
         eq_(exception_name, EXCEPTION.__class__.__name__)
         eq_(response.json[exception_name], EXCEPTION_ARGS)
+
+
+@patch('app.main.memcached', mock_memcached)
+class TestRecommendTask(TestCase):
+    task = recommend
+
+    @patch('app.search.recommendation.SearchRecommendation.do_search')
+    def test_recommend(self, mock_do_search):
+        mock_do_search.return_value = RESULTS
+        results = self.task.apply(args=[QUERY, KEY]).get()
+        eq_(results, RESULTS)
+        eq_(mock_memcached.get(KEY), RESULTS)

--- a/app/tests/test_memorize.py
+++ b/app/tests/test_memorize.py
@@ -5,7 +5,7 @@ from mock import patch
 from nose.tools import eq_, ok_
 from wrapt import ObjectProxy
 
-from app.memorize import CacheMissError, memorize, MemorizedObject
+from app.memorize import memorize, MemorizedObject
 from app.tests.memcached import mock_memcached
 
 
@@ -23,10 +23,6 @@ class SampleObject(object):
 
     @memorize(prefix=PREFIX)
     def prefix(self, *args, **kwargs):
-        return object()
-
-    @memorize(error_on_miss=True)
-    def error_on_miss(self, *args, **kwargs):
         return object()
 
 
@@ -98,11 +94,6 @@ class TestMemorize(TestCase):
         ok_(self._key(b='c') != self._key('a', b='c'))
         ok_(self._key(), self._key(fn='no_args_2'))
         ok_(self._key(), self._key(fn='prefix'))
-
-    def test_error_on_miss(self):
-        self._memorized('no_args')
-        with self.assertRaises(CacheMissError):
-            self._memorized('error_on_miss')
 
     def test_memorized_object_props(self):
         obj_cold = self._memorized('no_args')

--- a/app/util.py
+++ b/app/util.py
@@ -1,0 +1,15 @@
+def make_queue(app):
+    from celery import Celery
+    queue = Celery(app.import_name, broker=app.config['CELERY_BROKER_URL'])
+    queue.conf.update(app.config)
+    TaskBase = queue.Task
+
+    class ContextTask(TaskBase):
+        abstract = True
+
+        def __call__(self, *args, **kwargs):
+            with app.app_context():
+                return TaskBase.__call__(self, *args, **kwargs)
+
+    queue.Task = ContextTask
+    return queue

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,21 @@
 app:
   build: ./app
-  restart: always
+  command: uwsgi --http :8000 --wsgi-file /app/main.py --master
+  env_file: .env
   expose:
     - "8000"
-  env_file: .env
-  entrypoint: /app/entry.sh
-  environment:
-    - MEMCACHED_HOST=memcached:11211
   links:
     - memcached
+    - redis
+  restart: always
 
 nginx:
   build: ./conf/nginx
-  restart: always
-  ports:
-    - "80:80"
   links:
     - app
+  ports:
+    - "80:80"
+  restart: always
 
 memcached:
   image: memcached
@@ -26,12 +25,14 @@ memcached:
 
 redis:
   image: redis
-  expose:
-    - "6379"
 
 celery:
-  image: celery
-  links:
-    - redis
+  build: ./app
+  command: celery worker --app=app.main
+  env_file: .env
   environment:
-    - CELERY_BROKER_URL=redis://redis:6379
+    - CELERY_BROKER_URL=redis://redis:6379/0
+  links:
+    - memcached
+    - redis
+  restart: always


### PR DESCRIPTION
* Configures a celery container to run alongside the application container.
* Configures a redis broker for celery.
* Removes the error_on_miss option from the @memorize decorator, which is not possible to manage in a queue as originally intended due to how pickle treats differently-formed imports of the same module as separate modules.
* Updates the main route to interface directly with memcached.

r? @6a68 