### PR TITLE
Get coveralls working with the new CircleCI setup (fixes #47).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ python:
   - "3.5"
 install:
   - "pip install -r app/requirements.txt"
-  - "pip install coveralls flake8"
 script:
-  - "python setup.py test"
-  - "flake8 ."
-  - "coverage run --source=app setup.py test"
+  - "nosetests --cover-min-percentage=100 --with-coverage --cover-package=app"
 after_success: coveralls


### PR DESCRIPTION
Turns out, it's really complicated to run coveralls inside of the Docker container. So let's run tests both in Circle and Travis:

- Circle for the tests in a Docker container, build, push to Docker Hub, and linting.
- Travis for the tests outside of Docker and code coverage. 

Badge for this branch: ![](https://coveralls.io/repos/mozilla/universal-search-recommendation/badge.svg?branch=47-circleci-coveralls&service=github)

r? @6a68 