### PR TITLE
Docker tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,22 @@ MAINTAINER https://mail.mozilla.org/listinfo/testpilot-dev
 RUN groupadd --gid 10001 app && \
     useradd --uid 10001 --gid 10001 --shell /usr/sbin/nologin app
 
+WORKDIR /app
+
 # Install libmemcached-dev, whose C libraries are required by pylibmc.
-RUN apt-get -qq update && apt-get -qq install -y libmemcached-dev=1.0.18-4
+RUN apt-get -qq update && \
+    apt-get -qq install -y libmemcached-dev=1.0.18-4
 
 COPY ./requirements.txt /app/requirements.txt
 RUN pip install --upgrade --no-cache-dir -r /app/requirements.txt
 
-COPY . /app
 ENV PYTHONPATH $PYTHONPATH:/app
+EXPOSE 8000
+
+# Run the web service by default.
+ENTRYPOINT ["/app/conf/run.sh"]
+CMD ["web"]
+
+COPY . /app
 
 USER app
-EXPOSE 8000
-ENTRYPOINT ["/app/conf/web.sh"]

--- a/circle.yml
+++ b/circle.yml
@@ -29,8 +29,7 @@ dependencies:
 # Run flake8 and the Python test suite via nose.
 test:
   override:
-    - docker run -d app:build sh -c 'flake8 . --exclude=app/src && nosetests --exclude-dir=app/src'
-
+    - docker run app:build test
 
 # Tag and push the container to Docker Hub.
 deployment:

--- a/conf/run.sh
+++ b/conf/run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+cd $(dirname $0)
+case "$1" in
+    web)
+        echo "Starting Web Server"
+        exec ./web.sh
+        ;;
+    worker)
+        echo "Starting Celery Worker"
+        exec ./worker.sh
+        ;;
+    test)
+        echo "Running Tests"
+        cd ..
+        flake8 . --exclude=./recommendation/views/data/dummy.py && nosetests
+        ;;
+    *)
+        echo "Usage: $0 {web|worker|test}"
+        exit 1
+esac

--- a/conf/web.sh
+++ b/conf/web.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-uwsgi --http :${PORT:-8000} --wsgi-file /app/recommendation/wsgi.py --master
+exec uwsgi --http :${PORT:-8000} --wsgi-file /app/recommendation/wsgi.py --master

--- a/conf/worker.sh
+++ b/conf/worker.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-celery worker --app=recommendation
+exec celery worker --app=recommendation


### PR DESCRIPTION
Found some bugs/tweaks in the Docker scripts that needed addressing. 

- add conf/run.sh to use as the ENTRYPOINT for the container
- added `exec` instruction to shell scripts, nicer for handling signals (SIGKIL, SIGINT, etc)
- fix tests, they actually run now and don't error out on test data

@chuckharmston r? I think this is ready to merge.
