### PR TITLE
Bumps Werkzeug point version to 0.11.5.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ redis==2.10.5
 requests==2.9.1
 responses==0.5.1
 uwsgi==2.0.12
-Werkzeug==0.11.4
+Werkzeug==0.11.5
 wheel==0.29.0
 wrapt==1.10.6


### PR DESCRIPTION
Only change:

- werkzeug.serving: Fix crash when attempting SSL connection to HTTP server.