### PR TITLE
Removes mock requirement; replaces with stdlib mock library.

### DIFF
--- a/recommendation/mozlog/tests/test_middleware.py
+++ b/recommendation/mozlog/tests/test_middleware.py
@@ -1,7 +1,7 @@
 import json
 from time import time
+from unittest.mock import MagicMock, patch
 
-from mock import MagicMock, patch
 from nose.tools import eq_, ok_
 
 from recommendation.mozlog.middleware import request_summary, request_timer

--- a/recommendation/search/classification/tests/test_logo.py
+++ b/recommendation/search/classification/tests/test_logo.py
@@ -1,8 +1,8 @@
 from unittest import TestCase
+from unittest.mock import patch
 from urllib.parse import ParseResult
 
 import responses
-from mock import patch
 from nose.tools import eq_, ok_
 
 from recommendation.search.classification.logo import LogoClassifier

--- a/recommendation/search/suggest/tests/test_base.py
+++ b/recommendation/search/suggest/tests/test_base.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
+from unittest.mock import patch
 
-from mock import patch
 from nose.tools import eq_, ok_
 
 from recommendation.search.suggest.base import BaseSuggestionEngine

--- a/recommendation/search/suggest/tests/test_bing.py
+++ b/recommendation/search/suggest/tests/test_bing.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
+from unittest.mock import patch
 
 import responses
-from mock import patch
 from nose.tools import eq_, ok_
 
 from recommendation.search.suggest.bing import BingSuggestionEngine

--- a/recommendation/search/tests/test_recommendation.py
+++ b/recommendation/search/tests/test_recommendation.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
+from unittest.mock import patch
 
-from mock import patch
 from nose.tools import eq_, ok_
 
 from recommendation.search.classification.logo import LogoClassifier

--- a/recommendation/tasks/tests/test_recommend.py
+++ b/recommendation/tasks/tests/test_recommend.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
+from unittest.mock import patch
 
-from mock import patch
 from nose.tools import eq_
 
 from recommendation.tests.memcached import mock_memcached

--- a/recommendation/tests/test_factory.py
+++ b/recommendation/tests/test_factory.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
+from unittest.mock import patch
 
 from celery.app.base import Celery
-from mock import patch
 from nose.tools import eq_, ok_
 
 from recommendation.cors import cors_headers

--- a/recommendation/tests/test_main.py
+++ b/recommendation/tests/test_main.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlencode
+from unittest.mock import patch
 
 from flask.ext.testing import TestCase as FlaskTestCase
-from mock import patch
 from nose.tools import eq_, ok_
 
 from recommendation.cors import cors_headers

--- a/recommendation/tests/test_memorize.py
+++ b/recommendation/tests/test_memorize.py
@@ -1,7 +1,7 @@
 import pickle
 from unittest import TestCase
+from unittest.mock import patch
 
-from mock import patch
 from nose.tools import eq_, ok_
 from wrapt import ObjectProxy
 

--- a/recommendation/views/tests/test_main.py
+++ b/recommendation/views/tests/test_main.py
@@ -1,6 +1,6 @@
 from urllib.parse import urlencode
+from unittest.mock import patch
 
-from mock import patch
 from nose.tools import eq_, ok_
 
 from recommendation.conf import CACHE_TTL

--- a/recommendation/views/tests/test_status.py
+++ b/recommendation/views/tests/test_status.py
@@ -1,7 +1,7 @@
 import json
 from os import path
+from unittest.mock import patch
 
-from mock import patch
 from nose.tools import eq_, ok_
 from redis.exceptions import ConnectionError as RedisError
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ itsdangerous==0.24
 Jinja2==2.8
 jsonschema==2.5.1
 MarkupSafe==0.23
-mock==1.3.0
 nose==1.3.7
 nose-exclude==0.4.1
 oauth2==1.9.0.post1


### PR DESCRIPTION
I'm not sure why I required the mock library; it's been included with Python since 3.3. Instead of updating to 2.0, let's just remove the need for it entirely.