### PR TITLE
support Dockerflow requirement for saving the sha of the docker image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,11 +16,19 @@ dependencies:
 
     # Create a version.json file for the app to serve; copy it to the CircleCI
     # artifacts directory for debugging.
-    - printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s"}\n' "$CIRCLE_SHA1" "`python -c 'from recommendation import VERSION;print(VERSION)'`" "$CIRCLE_PROJECT_USERNAME" "$CIRCLE_PROJECT_REPONAME" > recommendation/static/version.json
+    - >
+        printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' 
+        "$CIRCLE_SHA1" 
+        "`python -c 'from recommendation import VERSION;print(VERSION)'`" 
+        "$CIRCLE_PROJECT_USERNAME" 
+        "$CIRCLE_PROJECT_REPONAME" 
+        "$CIRCLE_BUILD_URL"
+        > recommendation/static/version.json
     - cp recommendation/static/version.json $CIRCLE_ARTIFACTS
 
     # build the actual deployment container
     - docker build -t app:build .
+    - docker images --no-trunc | awk '/^app/ {print $3}' | tee $CIRCLE_ARTIFACTS/docker-image-shasum256.txt
 
     # Clean up any old images; save the new one.
     - I="image-$(date +%j).tgz"; mkdir -p ~/docker; rm ~/docker/*; docker save app:build | gzip -c > ~/docker/$I; ls -l ~/docker


### PR DESCRIPTION
Tweaked to match [Dockerflow](https://github.com/mozilla-services/Dockerflow)'s new requirement for archiving the SHA256 hash of the upload image. This helps with verification that what is being deployed is what was originally built. 