### PR TITLE
refactor to run on alpine linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# testing files
+version.json
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,13 @@ RUN addgroup -g 10001 app && \
 
 WORKDIR /app
 
-RUN apk add --update libmemcached-dev zlib-dev
+# Run the web service by default.
+ENTRYPOINT ["/app/conf/run.sh"]
+CMD ["web"]
 
 COPY ./requirements.txt /app/requirements.txt
 
-# install depenencies, cleanup and add libstdc++ back in since
-# we the app needs to link to it
+# install dependencies, cleanup
 RUN apk add --update build-base libmemcached-dev zlib-dev linux-headers && \
     pip install --upgrade --no-cache-dir pip && \
     pip install --upgrade --no-cache-dir -r requirements.txt && \
@@ -23,10 +24,6 @@ RUN apk add --update build-base libmemcached-dev zlib-dev linux-headers && \
 
 ENV PYTHONPATH $PYTHONPATH:/app
 EXPOSE 8000
-
-# Run the web service by default.
-ENTRYPOINT ["/app/conf/run.sh"]
-CMD ["web"]
 
 COPY . /app
 

--- a/conf/run.sh
+++ b/conf/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 cd $(dirname $0)
 case "$1" in

--- a/conf/web.sh
+++ b/conf/web.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 exec uwsgi --wsgi-disable-file-wrapper --http :${PORT:-8000} --wsgi-file /app/recommendation/wsgi.py --master

--- a/conf/worker.sh
+++ b/conf/worker.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 exec celery worker --app=recommendation

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ requests==2.10.0
 responses==0.5.1
 six==1.10.0
 testfixtures==4.9.1
-uWSGI==2.0.12
+uWSGI==2.0.13.1
 Werkzeug==0.11.9
 wheel==0.29.0
 wrapt==1.10.8


### PR DESCRIPTION
This builds a docker image that is about 110MB by basing off of python:3.5-alpine. In contrast, python:3.5 builds a 717MB image. 
